### PR TITLE
include api version in oauth access URL

### DIFF
--- a/R/UserSession.R
+++ b/R/UserSession.R
@@ -188,7 +188,7 @@ UserSession <- R6::R6Class(
         endpoint = httr::oauth_endpoint(
           authorize = NULL,
           access = paste0(
-            self$settings$basePath, "/login")),
+            self$settings$basePath, "/api/", self$settings$apiVersion, "/login")),
         app = httr::oauth_app(
           appname = "lookr",
           key = self$settings$clientId,


### PR DESCRIPTION
Looker returns a 403 when api version is omitted from URL

python example here: https://github.com/looker-open-source/sdk-codegen/blob/4c0f8c9a52ed2e0a40f8c65c5e531fb4f54a0491/python/looker_sdk/rtl/auth_session.py#L151

unclear if this work in all cases ... just unblocking teammates